### PR TITLE
[FEATURE] Model attribute descriptors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,9 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.DomainStore = exports.BaseModel = exports.type = undefined;
+
+var _modelDescriptors = require('./model-descriptors');
 
 var _baseModel = require('./base-model');
 
@@ -12,7 +15,6 @@ var _domainStore2 = _interopRequireDefault(_domainStore);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.default = {
-  BaseModel: _baseModel2.default,
-  DomainStore: _domainStore2.default
-};
+exports.type = _modelDescriptors.type;
+exports.BaseModel = _baseModel2.default;
+exports.DomainStore = _domainStore2.default;

--- a/lib/model-descriptors.js
+++ b/lib/model-descriptors.js
@@ -1,0 +1,43 @@
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.type = undefined;
+
+var _keys = require('babel-runtime/core-js/object/keys');
+
+var _keys2 = _interopRequireDefault(_keys);
+
+var _freeze = require('babel-runtime/core-js/object/freeze');
+
+var _freeze2 = _interopRequireDefault(_freeze);
+
+var _propUtils = require('@ngyv/prop-utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var TYPE_OPTIONS = (0, _freeze2.default)(['required', 'default']);
+
+var TYPE_NAMES = (0, _keys2.default)(_propUtils.types);
+/**
+ * Takes in model descriptors and returns a flat object
+ * @param  {string} typeName  String representation of prop types
+ * @param  {boolean} required  Indicates validation
+ * @param  {(number|boolean|string|array|object)} default  Fallback value
+ * @return {object}
+ */
+var type = function type(typeName) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  if (!TYPE_NAMES.includes(typeName)) {
+    throw new TypeError('Unexpected "' + typeName + '" passed as "typeName"');
+  }
+
+  return (0, _keys2.default)(options).reduce(function (hashType, optionKey) {
+    if (TYPE_OPTIONS.includes(optionKey)) {
+      hashType[optionKey] = options[optionKey];
+    }
+    return hashType;
+  }, { type: _propUtils.types[typeName] });
+};
+
+exports.type = type;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
+import { type } from './model-descriptors'
 import BaseModel from './base-model'
 import DomainStore from './domain-store'
 
-export default {
+export {
+  type,
   BaseModel,
   DomainStore
 }

--- a/src/model-descriptors.js
+++ b/src/model-descriptors.js
@@ -1,0 +1,32 @@
+import { types as propTypes } from '@ngyv/prop-utils'
+
+const TYPE_OPTIONS = Object.freeze([
+  'required',
+  'default'
+])
+
+const TYPE_NAMES = Object.keys(propTypes)
+
+/**
+ * Takes in model descriptors and returns a flat object
+ * @param  {string} typeName  String representation of prop types
+ * @param  {boolean} required  Indicates validation
+ * @param  {(number|boolean|string|array|object)} default  Fallback value
+ * @return {object}
+ */
+const type = (typeName, options = {}) => {
+  if (!TYPE_NAMES.includes(typeName)) {
+    throw new TypeError(`Unexpected "${typeName}" passed as "typeName"`)
+  }
+
+  return Object.keys(options).reduce((hashType, optionKey) => {
+    if (TYPE_OPTIONS.includes(optionKey)) {
+      hashType[optionKey] = options[optionKey]
+    }
+    return hashType
+  }, { type: propTypes[typeName] })
+}
+
+export {
+  type
+}

--- a/test/base-model-test.js
+++ b/test/base-model-test.js
@@ -1,10 +1,8 @@
 import test from 'ava'
 import { types } from '@ngyv/prop-utils'
-import reModelr from '../lib'
+import { BaseModel } from '../lib'
 
 test.beforeEach(t => {
-  const { BaseModel } = reModelr
-
   class User extends BaseModel {
     _attributes() {
       const defaultAttributes = super._attributes()

--- a/test/domain-store-test.js
+++ b/test/domain-store-test.js
@@ -1,11 +1,9 @@
 import test from 'ava'
 import http from 'ava-http'
 import { types } from '@ngyv/prop-utils'
-import reModelr from '../lib'
+import { BaseModel, DomainStore } from '../lib'
 
 test.beforeEach(t => {
-  const { BaseModel, DomainStore } = reModelr
-
   class User extends BaseModel {
     _attributes() {
       const defaultAttributes = super._attributes()

--- a/test/domain-store-unit-test.js
+++ b/test/domain-store-unit-test.js
@@ -1,7 +1,6 @@
 import test from 'ava'
 import { types, identify } from '@ngyv/prop-utils'
-import reModelr from '../lib'
-const { BaseModel, DomainStore } = reModelr
+import { BaseModel, DomainStore } from '../lib'
 
 test.beforeEach(t => {
   const mockBasePath = 'http://localhost:3000/api'

--- a/test/model-descriptors-test.js
+++ b/test/model-descriptors-test.js
@@ -1,0 +1,17 @@
+import test from 'ava'
+import { type } from  '../lib'
+import { types as propTypes } from '@ngyv/prop-utils'
+
+test('Model descriptors | type', t => {
+  t.plan(16)
+
+  const error = t.throws(() => {
+    type('random')
+  }, TypeError)
+  t.is(error.message, 'Unexpected "random" passed as "typeName"')
+  Object.keys(propTypes).forEach((typeName) => t.deepEqual(type(typeName), { type: propTypes[typeName] }, 'Returns simple object with "type" as prop type value'))
+
+  t.deepEqual(type('object', { required: true }), { type: propTypes.object, required: true }, 'Includes "required" option')
+  t.deepEqual(type('array', { default: [] }), { type: propTypes.array, default: [] }, 'Includes "default" option')
+  t.deepEqual(type('boolean', { required: true, randomOption: true }), { type: propTypes.boolean, required: true }, 'Does not included whitelisted options')
+})


### PR DESCRIPTION
### New usage

```js
class User extends BaseModel {
  _attributes() {
    return {
      id: type('number', { required: true}), // see notes below
      name: type('string', { default: 'Siti'}),
    }
  }
}
```
### Side effect

`_validateAttributes` in base model would always validate regardless of `required` option passed because `type` returns an `object`

The logic for type checking, parsing, and fallback to default value is still not implemented