### PR TITLE
[REFACTOR] Move validation logic to model descriptors

### DIFF
--- a/lib/base-model.js
+++ b/lib/base-model.js
@@ -2,10 +2,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
-
-var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
-
 var _keys = require('babel-runtime/core-js/object/keys');
 
 var _keys2 = _interopRequireDefault(_keys);
@@ -26,9 +22,13 @@ var _createClass2 = require('babel-runtime/helpers/createClass');
 
 var _createClass3 = _interopRequireDefault(_createClass2);
 
-var _lodash = require('lodash.snakecase');
+var _lodash = require('lodash.camelcase');
 
 var _lodash2 = _interopRequireDefault(_lodash);
+
+var _lodash3 = require('lodash.snakecase');
+
+var _lodash4 = _interopRequireDefault(_lodash3);
 
 var _modelDescriptors = require('./model-descriptors');
 
@@ -59,7 +59,8 @@ var BaseModel = function () {
     }
     this._store = domainStore;
 
-    this._validateAttributes(modelJson);
+    this._validateAttributes(modelJson); // does not block serialization now
+
     this._deserialize(modelJson);
     this._cache(modelJson);
     // observe this
@@ -79,9 +80,9 @@ var BaseModel = function () {
     key: '_attributes',
     value: function _attributes() {
       return {
-        id: _propUtils.types.number,
-        createdAt: _propUtils.types.date,
-        updatedAt: _propUtils.types.date
+        id: (0, _modelDescriptors.type)('number', { required: true }),
+        createdAt: (0, _modelDescriptors.type)('string'), //TODO: remove hack by adding parser
+        updatedAt: (0, _modelDescriptors.type)('string')
       };
     }
   }, {
@@ -99,39 +100,16 @@ var BaseModel = function () {
     key: '_serialize',
     value: function _serialize() {
       var serializable = this.constructor._serializable || this._data;
-      return pluckSubset(serializable, this, this, _lodash2.default);
+      return pluckSubset(serializable, this, this, _lodash4.default);
     }
   }, {
     key: '_validateAttributes',
     value: function _validateAttributes(modelJson) {
-      var type = (0, _propUtils.identify)(modelJson);
-
-      if (type !== _propUtils.types.object) {
-        throw new TypeError('Non-object passed');
-      }
-
-      if ((0, _keys2.default)(modelJson).length === 0) {
-        throw new TypeError('Empty json object');
-      }
-
-      var attributes = this._attributes();
-      (0, _keys2.default)(modelJson).forEach(function (attributeName) {
-        var expected = attributes[attributeName];
-        var acceptedTypes = {
-          nil: [_propUtils.types.undefined, _propUtils.types.null],
-          strings: [_propUtils.types.emptyString, _propUtils.types.string, _propUtils.types.null]
-
-          // model descriptors
-        };if ((0, _propUtils.identify)(expected) === _propUtils.types.object) {
-          if (!expected.type) {
-            throw new TypeError('Attribute "type" for "' + attributeName + '" is not specified');
-          }
-
-          acceptedTypes = (0, _propUtils.comparePropertyToType)(expected.validate, _propUtils.types.array) ? { ignore: [expected.type].concat((0, _toConsumableArray3.default)(expected.acceptedTypes)) } : acceptedTypes;
-
-          return (0, _modelDescriptors.validate)(modelJson[attributeName], (0, _assign2.default)({}, expected, { acceptedTypes: acceptedTypes }));
-        }
-      });
+      var camelcaseJson = (0, _keys2.default)(modelJson || {}).reduce(function (camelcaseJson, key) {
+        camelcaseJson[(0, _lodash2.default)(key)] = modelJson[key];
+        return camelcaseJson;
+      }, {});
+      return (0, _modelDescriptors._validateAttributes)(camelcaseJson, this._attributes());
     }
   }, {
     key: 'get',

--- a/lib/model-descriptors.js
+++ b/lib/model-descriptors.js
@@ -1,7 +1,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.validate = exports.type = undefined;
+exports._validateAttributes = exports.validate = exports.type = undefined;
+
+var _assign = require('babel-runtime/core-js/object/assign');
+
+var _assign2 = _interopRequireDefault(_assign);
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
 
 var _keys = require('babel-runtime/core-js/object/keys');
 
@@ -19,6 +27,10 @@ var TYPE_OPTIONS = (0, _freeze2.default)(['required', 'default', 'acceptedTypes'
 
 var TYPE_NAMES = (0, _keys2.default)(_propUtils.types);
 
+var ACCEPTED_TYPES = (0, _freeze2.default)({
+  nil: [_propUtils.types.undefined, _propUtils.types.null],
+  strings: [_propUtils.types.emptyString, _propUtils.types.string, _propUtils.types.null]
+});
 /**
  * Takes in model descriptors and returns a flat object
  * @param  {string} typeName  String representation of prop types
@@ -66,5 +78,47 @@ var validate = function validate(attribute) {
   return true;
 };
 
+/**
+ * @private _validateAttributes
+ * @param  {object} modelJson  Will be validated against the attributes
+ * @param  {object} attributes  Each property contains the type to be validated
+ * @return {boolean}
+ */
+var _validateAttributes = function _validateAttributes(modelJson, attributes) {
+  if (!(0, _propUtils.comparePropertyToType)(modelJson, _propUtils.types.object) || !(0, _propUtils.comparePropertyToType)(attributes, _propUtils.types.object)) {
+    throw new TypeError('Non-object passed');
+  }
+
+  var warn = false,
+      validated = true,
+      missingDescriptors = [];
+  (0, _keys2.default)(modelJson).forEach(function (attributeName) {
+    var expected = attributes[attributeName];
+
+    // model descriptors
+    if ((0, _propUtils.comparePropertyToType)(expected, _propUtils.types.object)) {
+      if (!expected.type) {
+        throw new TypeError('Attribute "type" for "' + attributeName + '" is not specified');
+      }
+
+      var acceptedTypes = (0, _propUtils.comparePropertyToType)(expected.acceptedTypes, _propUtils.types.array) ? { ignore: [expected.type].concat((0, _toConsumableArray3.default)(expected.acceptedTypes)) } : ACCEPTED_TYPES;
+
+      if (!validate(modelJson[attributeName], (0, _assign2.default)({}, expected, { acceptedTypes: acceptedTypes }))) {
+        validated = false;
+      }
+    } else {
+      missingDescriptors.push(attributeName);
+      warn = true;
+    }
+  });
+
+  if (warn) {
+    console.warn('Please use "type" function to describe model attributes (' + missingDescriptors.toString() + ')'); // eslint-disable-line no-console
+  }
+
+  return validated;
+};
+
 exports.type = type;
 exports.validate = validate;
+exports._validateAttributes = _validateAttributes;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ngyv/re-modelr",
-  "version": "0.8.14",
+  "version": "0.9.0",
   "description": "Simple-to-use javascript object-relational mapping store",
   "license": "MIT",
   "repository": {

--- a/test/base-model-test.js
+++ b/test/base-model-test.js
@@ -9,6 +9,7 @@ test.beforeEach(t => {
       const userAttributes = {
         name: type('string', { required: true, acceptedTypes: [propTypes.undefined, propTypes.null, propTypes.emptyString] }),
         favouriteFood: type('array'),
+        likes: type('string'),
       }
       return Object.assign({}, defaultAttributes, userAttributes)
     }
@@ -19,8 +20,8 @@ test.beforeEach(t => {
   let userModel = new User(userStore, {
     id: 1,
     name: 'Avo',
-    createdAt: new Date(),
-    updatedAt: new Date(),
+    createdAt: 'Tue May 08 2018 18:29:39 GMT+0800 (+08)', // TODO: remove hack after parser
+    updatedAt: 'Tue May 08 2018 18:29:39 GMT+0800 (+08)',
   })
 
   t.context.UserClass = User
@@ -50,7 +51,7 @@ test('Base model | creates user', t => {
   let anotherUser = new t.context.UserClass(t.context.userStore, {
     id: 2,
     name: 'Cado',
-    favourite_food: ['poke', 'pho'],
+    favouriteFood: ['poke', 'pho'],
   },
   {
     isNew: true,

--- a/test/domain-store-unit-test.js
+++ b/test/domain-store-unit-test.js
@@ -1,13 +1,21 @@
 import test from 'ava'
-import { types, identify } from '@ngyv/prop-utils'
-import { BaseModel, DomainStore } from '../lib'
+import { types as propTypes, identify } from '@ngyv/prop-utils'
+import { type, BaseModel, DomainStore } from '../lib'
 
 test.beforeEach(t => {
   const mockBasePath = 'http://localhost:3000/api'
-
+  class Model extends BaseModel {
+    _attributes() {
+      const defaultAttributes = super._attributes()
+      const userAttributes = {
+        color: type('string'),
+      }
+      return Object.assign({}, defaultAttributes, userAttributes)
+    }
+  }
   class Store extends DomainStore {
     constructor() {
-      super(BaseModel, { basePath: mockBasePath })
+      super(Model, { basePath: mockBasePath })
     }
   }
   t.context.Store = Store
@@ -37,7 +45,7 @@ test('Domain Store | _generateApi', t => {
   t.deepEqual(Object.keys(store._api), ['get', 'post', 'put', 'delete'], '_api is object with fetch method names')
   let allFunctions = true
   Object.keys(store._api).forEach(key => {
-    if(identify(store._api[key]) !== types.function) {
+    if(identify(store._api[key]) !== propTypes.function) {
       allFunctions = false
     }
   })
@@ -61,7 +69,7 @@ test('Domain Store | _normalizeModels', t => {
   const entries = store._normalizeModels(jsonArray)
   t.deepEqual(Object.keys(entries), ['1', '2', 'length'], 'Normalizes models as hash of model ids with length as keys')
   t.is(entries.length, jsonArray.length, 'Entries length is same as json array')
-  t.is(entries[2].constructor.name, 'BaseModel', 'Entries contains BaseModel')
+  t.is(entries[2].constructor.name, 'Model', 'Entries contains BaseModel')
 })
 
 test('Domain Store | _pushEntry', t => assertCallApiMethodVerifyPushedEntry(t, { classProperty: '_pushEntry', modelJson: { id: 1 } }))

--- a/test/fixtures/localhost/delete_api_users_1-13y-hP.json
+++ b/test/fixtures/localhost/delete_api_users_1-13y-hP.json
@@ -31,7 +31,7 @@
     "Close"
   ],
   "response": {
-    "age": "21",
+    "age": 21,
     "created_at": "2018-02-11T10:34:22.032Z",
     "favourite_food": [
       "nasi lemak",

--- a/test/model-descriptors-test.js
+++ b/test/model-descriptors-test.js
@@ -1,5 +1,6 @@
 import test from 'ava'
-import { type, validate } from  '../lib'
+import { type, validate, } from  '../lib' // public
+import { _validateAttributes } from '../lib/model-descriptors' // private
 import { types as propTypes } from '@ngyv/prop-utils'
 
 test('Model descriptors | type', t => {
@@ -34,4 +35,82 @@ test('Model descriptors | validate', t => {
   t.is(error.message, errorMessage)
 
   t.is(validate(attribute, describedType), false, 'Returns false after warning')
+})
+
+test('Model descriptors | _validateAttributes', t => {
+  t.plan(11)
+
+  const badModelJson = {
+    id: 'random',
+    age: 19,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+  }
+
+  const lessBadModelJson = {
+    id: 1,
+    age: 19,
+    updatedAt: new Date(),
+    createdAt: 'Not so bad',
+  }
+
+  const goodModelJson = {
+    id: 1,
+    age: 19,
+    updatedAt: new Date(),
+    createdAt: new Date(),
+  }
+
+  const lessBadAttributes = {
+    id: type('number', { required: true }),
+    age: type('number'),
+    updatedAt: propTypes.date,
+    createdAt: type('date'),
+  }
+
+  const badAttributes = {
+    id: type('number', { required: true }),
+    age: type('number'),
+    updatedAt: type('date'),
+    createdAt: { wrongTypeKey: propTypes.date },
+  }
+
+  const goodAttributes = {
+    id: type('number', { required: true }),
+    age: type('number'),
+    updatedAt: type('date'),
+    createdAt: type('date'),
+  }
+
+  const warnMessage = 'Please use "type" function to describe model attributes (updatedAt)'
+  const lessBadWarnMessage = 'Expected "date" but got property "Not so bad" of type "string" instead'
+  const errorObjectMessage = 'Non-object passed'
+  const errorJsonMessage = 'Expected "number" but got property "random" of type "string" instead'
+  const errorAttributeMessage = 'Attribute "type" for "createdAt" is not specified'
+
+  console.warn = (message) => { t.is(message, warnMessage, 'Warns instead of throwing error') }  // eslint-disable-line no-console
+
+  t.is(_validateAttributes(goodModelJson, lessBadAttributes), true, 'Returns true even if there are some attributes not described after warning')
+
+  const errorObject = t.throws(() => {
+    _validateAttributes(1, goodAttributes)
+  }, TypeError)
+
+  t.is(errorObject.message, errorObjectMessage)
+
+  const errorAttribute = t.throws(() => {
+    _validateAttributes(goodModelJson, badAttributes)
+  }, TypeError)
+
+  t.is(errorAttribute.message, errorAttributeMessage)
+
+  const errorJson = t.throws(() => {
+    _validateAttributes(badModelJson, goodAttributes)
+  }, TypeError)
+
+  t.is(errorJson.message, errorJsonMessage)
+
+  console.warn = (message) => { t.is(message, lessBadWarnMessage) } // eslint-disable-line no-console
+  t.is(_validateAttributes(lessBadModelJson, goodAttributes), false, 'Returns false if any of the attributes fails validation after warning')
+  t.is(_validateAttributes(goodModelJson, goodAttributes), true, 'Returns true if all attributes pass validation')
 })


### PR DESCRIPTION
Temporary hack of defining `date` properties as `string`. This is until the property parser is built.

Also, validation failure does not block instantiation of models.