### PR TITLE
[ENHANCEMENT] Set default value in `_validateAttributes`

### DIFF
--- a/lib/model-descriptors.js
+++ b/lib/model-descriptors.js
@@ -1,7 +1,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports._validateAttributes = exports.validate = exports.type = undefined;
+exports._validateAttributes = exports._defaultAttribute = exports.validate = exports.type = undefined;
 
 var _assign = require('babel-runtime/core-js/object/assign');
 
@@ -79,6 +79,21 @@ var validate = function validate(attribute) {
 };
 
 /**
+ * _defaultAttribute  will return the parsed attribute as default value if attribute is one of the overrideTypes
+ * @param  {*} attribute
+ * @param  {*} defaultValue
+ * @param  {Array}  i.e. [overrideTypes=[propTypes.undefined, propTypes.null]]
+ * @return {*}
+ */
+var _defaultAttribute = function _defaultAttribute(attribute, defaultValue, overrideTypes) {
+  if ((0, _propUtils.comparePropertyToType)(defaultValue, _propUtils.types.undefined)) {
+    return attribute;
+  }
+  var override = overrideTypes ? { override: [_propUtils.types.undefined, _propUtils.types.null] } : undefined;
+  return (0, _propUtils.comparePropertyToType)(attribute, _propUtils.types.undefined, override) ? defaultValue : attribute;
+};
+
+/**
  * @private _validateAttributes
  * @param  {object} modelJson  Will be validated against the attributes
  * @param  {object} attributes  Each property contains the type to be validated
@@ -101,9 +116,10 @@ var _validateAttributes = function _validateAttributes(modelJson, attributes) {
         throw new TypeError('Attribute "type" for "' + attributeName + '" is not specified');
       }
 
+      var jsonAttribute = _defaultAttribute(modelJson[attributeName], expected.default);
       var acceptedTypes = (0, _propUtils.comparePropertyToType)(expected.acceptedTypes, _propUtils.types.array) ? { ignore: [expected.type].concat((0, _toConsumableArray3.default)(expected.acceptedTypes)) } : ACCEPTED_TYPES;
 
-      if (!validate(modelJson[attributeName], (0, _assign2.default)({}, expected, { acceptedTypes: acceptedTypes }))) {
+      if (!validate(jsonAttribute, (0, _assign2.default)({}, expected, { acceptedTypes: acceptedTypes }))) {
         validated = false;
       }
     } else {
@@ -121,4 +137,5 @@ var _validateAttributes = function _validateAttributes(modelJson, attributes) {
 
 exports.type = type;
 exports.validate = validate;
+exports._defaultAttribute = _defaultAttribute;
 exports._validateAttributes = _validateAttributes;

--- a/src/model-descriptors.js
+++ b/src/model-descriptors.js
@@ -59,6 +59,21 @@ const validate = (attribute, type = {}) => {
 }
 
 /**
+ * _defaultAttribute  will return the parsed attribute as default value if attribute is one of the overrideTypes
+ * @param  {*} attribute
+ * @param  {*} defaultValue
+ * @param  {Array}  i.e. [overrideTypes=[propTypes.undefined, propTypes.null]]
+ * @return {*}
+ */
+const _defaultAttribute = (attribute, defaultValue, overrideTypes) => {
+  if (comparePropertyToType(defaultValue, propTypes.undefined)) {
+    return attribute
+  }
+  const override = overrideTypes ? { override: [propTypes.undefined, propTypes.null] } : undefined
+  return (comparePropertyToType(attribute, propTypes.undefined, override)) ? defaultValue : attribute
+}
+
+/**
  * @private _validateAttributes
  * @param  {object} modelJson  Will be validated against the attributes
  * @param  {object} attributes  Each property contains the type to be validated
@@ -79,9 +94,10 @@ const _validateAttributes = (modelJson, attributes) => {
         throw new TypeError(`Attribute "type" for "${attributeName}" is not specified`)
       }
 
+      const jsonAttribute = _defaultAttribute(modelJson[attributeName], expected.default)
       const acceptedTypes = comparePropertyToType(expected.acceptedTypes, propTypes.array) ? { ignore: [expected.type, ...expected.acceptedTypes] } : ACCEPTED_TYPES
 
-      if(!validate(modelJson[attributeName], Object.assign({}, expected, { acceptedTypes }))) {
+      if(!validate(jsonAttribute, Object.assign({}, expected, { acceptedTypes }))) {
         validated = false
       }
     } else {
@@ -100,5 +116,6 @@ const _validateAttributes = (modelJson, attributes) => {
 export {
   type,
   validate,
+  _defaultAttribute,
   _validateAttributes,
 }

--- a/test/model-descriptors-test.js
+++ b/test/model-descriptors-test.js
@@ -1,6 +1,16 @@
 import test from 'ava'
-import { type, validate, } from  '../lib' // public
-import { _validateAttributes } from '../lib/model-descriptors' // private
+// public
+import {
+  type,
+  validate,
+} from  '../lib'
+
+// private
+import {
+  _defaultAttribute,
+  _validateAttributes,
+} from '../lib/model-descriptors'
+
 import { types as propTypes } from '@ngyv/prop-utils'
 
 test('Model descriptors | type', t => {
@@ -35,6 +45,15 @@ test('Model descriptors | validate', t => {
   t.is(error.message, errorMessage)
 
   t.is(validate(attribute, describedType), false, 'Returns false after warning')
+})
+
+test('Model descriptors | _defaultAttribute', t => {
+  t.plan(4)
+
+  t.is(_defaultAttribute(null, undefined), null, 'Returns original attribute value if default value passed is undefined')
+  t.is(_defaultAttribute(null, 10), null, 'Returns original "null" value if overrideTypes is not passed')
+  t.is(_defaultAttribute(undefined, 'random'), 'random', 'Returns default value if attribute value undefined')
+  t.is(_defaultAttribute(null, 10, [propTypes.null]), 10, 'Returns default value if attribute value is in overrideTypes passed')
 })
 
 test('Model descriptors | _validateAttributes', t => {


### PR DESCRIPTION
Sets default value specified if the attribute value is `undefined` or `null`.

Also accepts `overrideTypes` options array which is by default `[propTypes.undefined, propTypes.null]`